### PR TITLE
[Feature] 댓글 작성 및 삭제 API 구현

### DIFF
--- a/src/comment/comment.controller.spec.ts
+++ b/src/comment/comment.controller.spec.ts
@@ -4,7 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule } from '@nestjs/config';
 import * as request from 'supertest';
 import { DataSource, Repository } from 'typeorm';
-
+import { UserModule } from '../user/user.module';
 import { User } from '../user/entities/user.entity';
 import { Post } from '../post/entities/post.entity';
 import { Comment } from './entities/comment.entity';
@@ -187,5 +187,168 @@ describe('CommentController POST /comment', () => {
       .expect(400);
 
     expect(res.body.message).toBe('부모 댓글과 게시물이 일치하지 않습니다.');
+  });
+});
+
+describe('CommentController DELETE /comment/:commentId', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+  let userRepository: Repository<User>;
+  let postRepository: Repository<Post>;
+  let commentRepository: Repository<Comment>;
+  let accessToken: string;
+  let user: User;
+  let post: Post;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true }),
+        TypeOrmModule.forRoot({
+          type: 'postgres',
+          host: process.env.DB_HOST,
+          port: Number(process.env.DB_TEST_PORT),
+          username: process.env.DB_USERNAME,
+          password: process.env.DB_PASSWORD,
+          database: process.env.DB_TEST_DATABASE,
+          synchronize: true,
+          autoLoadEntities: true,
+          entities: [User, Post, Comment, Like, File],
+        }),
+        TypeOrmModule.forFeature([User, Post, Comment, Like, File]),
+        AuthModule,
+        UserModule,
+        CommentModule,
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    await app.init();
+
+    dataSource = moduleFixture.get(DataSource);
+    userRepository = dataSource.getRepository(User);
+    postRepository = dataSource.getRepository(Post);
+    commentRepository = dataSource.getRepository(Comment);
+
+    // 유저 생성 및 로그인
+    const email = `comment-del-${Date.now()}@test.com`;
+    await request(app.getHttpServer()).post('/auth/signup').send({
+      email,
+      password: 'testpass123',
+      name: '댓글삭제자',
+      nickname: '삭제러',
+    });
+
+    const loginRes = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email, password: 'testpass123' });
+
+    accessToken = loginRes.body.accessToken;
+    user = await userRepository.findOneByOrFail({ email });
+
+    post = await postRepository.save({
+      title: '댓글용 글',
+      content: '삭제 테스트 글입니다.',
+      author: user,
+      isDeleted: false,
+    });
+  });
+
+  afterAll(async () => {
+    await commentRepository.delete({});
+    await postRepository.delete({});
+    await userRepository.delete({ id: user.id });
+    await app.close();
+  });
+
+  it('✅ 본인 댓글 삭제 → 200', async () => {
+    const comment = await commentRepository.save({
+      content: '삭제될 댓글',
+      post,
+      author: user,
+      isDeleted: false,
+    });
+
+    const res = await request(app.getHttpServer())
+      .delete(`/comment/${comment.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(res.body.message).toBe('댓글이 삭제되었습니다.');
+  });
+
+  it('❌ 존재하지 않는 댓글 삭제 → 404', async () => {
+    await request(app.getHttpServer())
+      .delete('/comment/999999')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(404);
+  });
+
+  it('❌ 이미 삭제된 댓글 삭제 → 404', async () => {
+    const deleted = await commentRepository.save({
+      content: '이미 삭제됨',
+      post,
+      author: user,
+      isDeleted: true,
+    });
+
+    await request(app.getHttpServer())
+      .delete(`/comment/${deleted.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(404);
+  });
+
+  it('❌ 다른 유저의 댓글 삭제 → 403', async () => {
+    const otherUser = await userRepository.save({
+      email: `other-${Date.now()}@test.com`,
+      password: '12345678',
+      name: '타인',
+      nickname: '남',
+      isDeleted: false,
+    });
+
+    const otherComment = await commentRepository.save({
+      content: '남의 댓글',
+      post,
+      author: otherUser,
+      isDeleted: false,
+    });
+
+    await request(app.getHttpServer())
+      .delete(`/comment/${otherComment.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(403);
+  });
+
+  it('❌ 토큰 없이 삭제 요청 → 401', async () => {
+    const comment = await commentRepository.save({
+      content: '비인가 삭제',
+      post,
+      author: user,
+      isDeleted: false,
+    });
+
+    await request(app.getHttpServer())
+      .delete(`/comment/${comment.id}`)
+      .expect(401);
+  });
+
+  it('❌ 탈퇴한 유저가 삭제 요청 → 401', async () => {
+    const comment = await commentRepository.save({
+      content: '탈퇴자 댓글',
+      post,
+      author: user,
+      isDeleted: false,
+    });
+
+    await userRepository.update({ id: user.id }, { isDeleted: true });
+
+    await request(app.getHttpServer())
+      .delete(`/comment/${comment.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(401);
+
+    await userRepository.update({ id: user.id }, { isDeleted: false });
   });
 });

--- a/src/comment/comment.controller.ts
+++ b/src/comment/comment.controller.ts
@@ -17,4 +17,13 @@ export class CommentController {
     const userId = req['user'].id;
     return this.commentService.create({ ...dto, authorId: userId });
   }
+
+  @Delete(':commentId')
+  deleteComment(
+    @Param('commentId') commentId: number,
+    @Req() req: Request,
+  ): Promise<{ message: string }> {
+    const userId = req['user'].id;
+    return this.commentService.delete(commentId, userId);
+  }
 }

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -1,6 +1,8 @@
 import { Module } from "@nestjs/common";
 import { AccessTokenGuard } from "./guard/access-token.guard";
 import { JwtModule } from "@nestjs/jwt";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { User } from "../user/entities/user.entity";
 
 @Module({
   imports: [
@@ -8,6 +10,7 @@ import { JwtModule } from "@nestjs/jwt";
       secret: process.env.ACCESS_TOKEN_SECRET,
       signOptions: { expiresIn: process.env.ACCESS_TOKEN_EXPIRES_IN },
     }),
+    TypeOrmModule.forFeature([User]),
   ],
   providers: [AccessTokenGuard],
   exports: [AccessTokenGuard, JwtModule],

--- a/src/common/guard/access-token.guard.ts
+++ b/src/common/guard/access-token.guard.ts
@@ -1,16 +1,26 @@
-import { Injectable, CanActivate, ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { JwtService } from '@nestjs/jwt';
+import { InjectRepository } from '@nestjs/typeorm';
 import { Request } from 'express';
+import { Repository } from 'typeorm';
+import { User } from '../../user/entities/user.entity';
 
 @Injectable()
 export class AccessTokenGuard implements CanActivate {
   constructor(
     private readonly jwtService: JwtService,
     private readonly reflector: Reflector,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
   ) {}
 
-  canActivate(context: ExecutionContext): boolean {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<Request>();
     const authHeader = request.headers.authorization;
 
@@ -19,14 +29,26 @@ export class AccessTokenGuard implements CanActivate {
     }
 
     const token = authHeader.split(' ')[1];
+
     try {
       const payload = this.jwtService.verify(token, {
         secret: process.env.ACCESS_TOKEN_SECRET,
       });
 
+      const user = await this.userRepository.findOneBy({ id: payload.id });
+
+      if (!user) {
+        throw new UnauthorizedException('유효하지 않은 Access Token입니다.');
+      }
+
+      if (user.isDeleted) {
+        throw new UnauthorizedException('존재하지 않는 사용자입니다.');
+      }
+
       request['user'] = payload;
       return true;
     } catch (err) {
+      if (err instanceof UnauthorizedException) throw err;
       throw new UnauthorizedException('유효하지 않은 Access Token입니다.');
     }
   }

--- a/src/post/post.controller.spec.ts
+++ b/src/post/post.controller.spec.ts
@@ -163,7 +163,7 @@ describe('PostController POST post', () => {
       .post('/post')
       .set('Authorization', `Bearer ${accessToken}`)
       .send({ title: '삭제된 유저', content: '본문입니다.', files: [] })
-      .expect(404);
+      .expect(401);
     await userRepository.update(user.id, { isDeleted: false });
   });
 


### PR DESCRIPTION
## ✨ Comment 기능 구현 완료 (댓글 작성 & 삭제)

댓글 기능을 도입하여 게시물에 대해 사용자들이 댓글 및 대댓글을 등록하고 삭제할 수 있도록 구현했습니다.  
AccessToken 기반 인증 및 다양한 예외 상황을 고려하여 Robust한 흐름을 구성했습니다.

---

### 🔧 주요 구현 내용

- **댓글 작성 (POST /comment)**
  - 부모 없는 일반 댓글 등록
  - 부모 있는 대댓글 등록
- **댓글 삭제 (DELETE /comment/:commentId)**
  - 본인 댓글만 삭제 가능
  - soft delete 처리 (isDeleted = true)

---

### 🔐 인증 처리
- `@UseGuards(AccessTokenGuard)` 사용
  - AccessToken 없거나 유효하지 않은 경우 → 401
  - 탈퇴한 유저인 경우 → 401 ("존재하지 않는 사용자입니다.")

---

### 🧪 테스트 커버리지 (E2E + 단위)

#### ✅ 댓글 작성 테스트 시나리오
- [x] 부모 없는 댓글 등록 → 201
- [x] 부모 있는 대댓글 등록 → 201
- [x] 존재하지 않는 게시물 → 404
- [x] 삭제된 게시물 → 404
- [x] 존재하지 않는 부모 댓글 → 404
- [x] 삭제된 부모 댓글 → 400
- [x] 부모 댓글과 게시물 불일치 → 400

#### ✅ 댓글 삭제 테스트 시나리오
- [x] 본인 댓글 삭제 → 200
- [x] 존재하지 않는 댓글 삭제 → 404
- [x] 이미 삭제된 댓글 → 404
- [x] 다른 유저의 댓글 삭제 → 403
- [x] AccessToken 없이 요청 → 401
- [x] 탈퇴한 유저의 요청 → 401

#### ✅ Service 단위 테스트 포함
- 핵심 로직에 대한 서비스 테스트도 모두 포함

---

### 📌 비고

- soft delete 방식을 사용하므로 댓글 복구 용이
- 댓글 생성 시 부모와 게시물 관계 일치 여부 확인
- 토큰 인증 시 `user.isDeleted`까지 검증하는 guard 개선 포함

---

### 🔗 관련 이슈
- close #6 
