### PR TITLE
[Feature] POST, DELETE like 기능 구현 완료

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,12 +11,6 @@ import { CommentModule } from './comment/comment.module';
 import { LoggerMiddleware } from './common/middleware/logger.middleware';
 import { AuthModule } from './auth/auth.module';
 import { CommonModule } from './common/common.module';
-import { PostStats } from './post/entities/post-stats.entity';
-import { User } from './user/entities/user.entity';
-import { Post } from './post/entities/post.entity';
-import { File } from './file/entities/file.entity';
-import { Comment } from './comment/entities/comment.entity';
-import { Like } from './like/entities/like.entity';
 
 @Module({
   imports: [

--- a/src/like/dto/create-like.dto.ts
+++ b/src/like/dto/create-like.dto.ts
@@ -1,1 +1,0 @@
-export class CreateLikeDto {}

--- a/src/like/dto/update-like.dto.ts
+++ b/src/like/dto/update-like.dto.ts
@@ -1,4 +1,0 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateLikeDto } from './create-like.dto';
-
-export class UpdateLikeDto extends PartialType(CreateLikeDto) {}

--- a/src/like/like.controller.ts
+++ b/src/like/like.controller.ts
@@ -1,34 +1,21 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards, Req } from '@nestjs/common';
 import { LikeService } from './like.service';
-import { CreateLikeDto } from './dto/create-like.dto';
-import { UpdateLikeDto } from './dto/update-like.dto';
+import { AccessTokenGuard } from 'src/common/guard/access-token.guard';
 
+@UseGuards(AccessTokenGuard)
 @Controller('like')
 export class LikeController {
   constructor(private readonly likeService: LikeService) {}
 
-  @Post()
-  create(@Body() createLikeDto: CreateLikeDto) {
-    return this.likeService.create(createLikeDto);
+  @Post(':postId')
+  likePost(@Param('postId') postId: number, @Req() req) {
+    const userId = req['user'].id;
+    return this.likeService.likePost(userId, postId);
   }
 
-  @Get()
-  findAll() {
-    return this.likeService.findAll();
-  }
-
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.likeService.findOne(+id);
-  }
-
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateLikeDto: UpdateLikeDto) {
-    return this.likeService.update(+id, updateLikeDto);
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.likeService.remove(+id);
+  @Delete(':postId')
+  unlikePost(@Param('postId') postId: number, @Req() req) {
+    const userId = req['user'].id;
+    return this.likeService.unlikePost(userId, postId);
   }
 }

--- a/src/like/like.module.ts
+++ b/src/like/like.module.ts
@@ -3,9 +3,12 @@ import { LikeService } from './like.service';
 import { LikeController } from './like.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Like } from './entities/like.entity';
+import { Post } from '../post/entities/post.entity';
+import { User } from '../user/entities/user.entity';
+import { CommonModule } from '../common/common.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Like])],
+  imports: [TypeOrmModule.forFeature([Like, Post, User]), CommonModule],
   controllers: [LikeController],
   providers: [LikeService],
 })

--- a/src/like/like.service.ts
+++ b/src/like/like.service.ts
@@ -1,26 +1,70 @@
-import { Injectable } from '@nestjs/common';
-import { CreateLikeDto } from './dto/create-like.dto';
-import { UpdateLikeDto } from './dto/update-like.dto';
+import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Like } from './entities/like.entity';
+import { Post } from '../post/entities/post.entity';
+import { User } from '../user/entities/user.entity';
 
 @Injectable()
 export class LikeService {
-  create(createLikeDto: CreateLikeDto) {
-    return 'This action adds a new like';
+  constructor(
+    @InjectRepository(Like)
+    private readonly likeRepository: Repository<Like>,
+
+    @InjectRepository(Post)
+    private readonly postRepository: Repository<Post>,
+
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  async likePost(userId: string, postId: number): Promise<{ message: string }> {
+    const post = await this.postRepository.findOne({ where: { id: postId } });
+    if (!post) {
+      throw new NotFoundException('게시글을 찾을 수 없습니다.');
+    }
+
+    const user = await this.userRepository.findOne({ where: { id: userId } });
+    if (!user || user.isDeleted) {
+      throw new NotFoundException('사용자를 찾을 수 없습니다.');
+    }
+
+    const existingLike = await this.likeRepository.findOne({
+      where: { user: { id: userId }, post: { id: postId } },
+    });
+    if (existingLike) {
+      throw new ForbiddenException('이미 좋아요를 누른 게시글입니다.');
+    }
+
+    const like = this.likeRepository.create({
+      user,
+      post,
+    });
+    await this.likeRepository.save(like);
+
+    return { message: '게시글 좋아요 등록 성공' };
   }
 
-  findAll() {
-    return `This action returns all like`;
-  }
+  async unlikePost(userId: string, postId: number): Promise<{ message: string }> {
+    const post = await this.postRepository.findOne({ where: { id: postId } });
+    if (!post) {
+      throw new NotFoundException('게시글을 찾을 수 없습니다.');
+    }
 
-  findOne(id: number) {
-    return `This action returns a #${id} like`;
-  }
+    const user = await this.userRepository.findOne({ where: { id: userId } });
+    if (!user || user.isDeleted) {
+      throw new NotFoundException('사용자를 찾을 수 없습니다.');
+    }
 
-  update(id: number, updateLikeDto: UpdateLikeDto) {
-    return `This action updates a #${id} like`;
-  }
+    const existingLike = await this.likeRepository.findOne({
+      where: { user: { id: userId }, post: { id: postId } },
+    });
+    if (!existingLike) {
+      throw new NotFoundException('좋아요가 등록되지 않은 게시글입니다.');
+    }
 
-  remove(id: number) {
-    return `This action removes a #${id} like`;
+    await this.likeRepository.remove(existingLike);
+
+    return { message: '게시글 좋아요 삭제 성공' };
   }
 }

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -15,7 +15,6 @@ import {
 } from '@nestjs/common';
 import { PostService } from './post.service';
 import { CreatePostDto } from './dto/create-post.dto';
-import { UpdatePostDto } from './dto/update-post.dto';
 import { AccessTokenGuard } from '../common/guard/access-token.guard';
 import { GetPostResponseDto } from './dto/get-post-response.dto';
 

--- a/src/post/post.module.ts
+++ b/src/post/post.module.ts
@@ -10,7 +10,7 @@ import { Comment } from '../comment/entities/comment.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Post, PostStats, User, File, Comment]),
+    TypeOrmModule.forFeature([Post, PostStats, User, Comment]),
     CommonModule,
   ],
   controllers: [PostController],

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -1,1 +1,0 @@
-export class CreateUserDto {}


### PR DESCRIPTION
# ✨ 게시글 좋아요 기능 구현 (등록, 삭제)

게시글 좋아요 등록 및 삭제 기능을 구현하였습니다. 사용자는 게시글에 좋아요를 등록하거나 삭제할 수 있습니다. 인증된 사용자만 접근할 수 있도록 `AccessToken`을 이용한 인증을 적용하였으며, 다양한 예외 상황을 처리하였습니다.

## 🔧 주요 구현 내용
- **게시글 좋아요 등록 (POST /like/:postId)**:
  - 게시글에 좋아요를 등록할 수 있습니다.
  - 이미 좋아요를 누른 게시글에 대해 다시 좋아요를 누르면 `ForbiddenException` 발생.
  
- **게시글 좋아요 삭제 (DELETE /like/:postId)**:
  - 게시글에 등록된 좋아요를 삭제할 수 있습니다.
  - 좋아요가 없는 게시글에 대해 삭제를 시도하면 `NotFoundException` 발생.

## 🔐 인증 처리
- `@UseGuards(AccessTokenGuard)`를 사용하여 인증을 요구합니다.
- 인증되지 않은 사용자는 401 상태 코드로 응답받습니다.

## 🔗 관련 이슈
- close  #12 
